### PR TITLE
Remove plugin 'python-mode/python-mode'

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -84,12 +84,9 @@ else
 
     " Python plugins
     if executable('python') || executable('python3')
-        " Plugin 'hynek/vim-python-pep8-indent'
-        " Plugin 'nvie/vim-flake8'
-        " Plugin 'tmhedberg/simpylfold'
-        " Plugin 'davidhalter/jedi-vim'
-        " Plugin 'alfredodeza/pytest.vim'
-        Plugin 'python-mode/python-mode'
+        Plugin 'hynek/vim-python-pep8-indent'
+        Plugin 'tmhedberg/simpylfold'
+        Plugin 'nvie/vim-flake8'
     endif
 
     " Rust plugins


### PR DESCRIPTION
I use vim as a lightweight editor. The python-mode plugin took a long
time to load and so I removed it. If I need to work/edit a full blown
project I would recomend using another ide i.e. VScode/PyCharm/etc.